### PR TITLE
Fixed build on osx/darwin

### DIFF
--- a/Chart-fltkhs.cabal
+++ b/Chart-fltkhs.cabal
@@ -67,10 +67,10 @@ library
                      "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc"
                      "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"
 
-    if os(osx)
-        ghc-options: " -optl-Wl,-lfltkc"
+    if os(darwin)
+        ghc-Options: "-optl-Wl,-lfltkc"
 
-    if (!os(osx) && !os(windows))
+    if (!os(darwin) && !os(windows))
         ghc-options:  -pgml g++ "-optl-Wl,--allow-multiple-definition"
                      "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc"
                      "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"
@@ -107,10 +107,10 @@ executable Example1
                     "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc"
                     "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"
 
-    if os(osx)
+    if os(darwin)
         ghc-options: "-optl-Wl,-lfltkc"
 
-    if (!os(osx) && !os(windows))
+    if (!os(darwin) && !os(windows))
         ghc-options: -pgml g++ "-optl-Wl,--allow-multiple-definition"
                     "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc"
                     "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"
@@ -152,10 +152,10 @@ executable Example2
                      "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc"
                      "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"
 
-    if os(osx)
+    if os(darwin)
         ghc-options: "-optl-Wl,-lfltkc"
 
-    if (!os(osx) && !os(windows))
+    if (!os(darwin) && !os(windows))
         ghc-options: -pgml g++ "-optl-Wl,--allow-multiple-definition"
                      "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc"
                      "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"
@@ -195,10 +195,10 @@ executable Example3
                      "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc"
                      "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"
 
-    if os(osx)
+    if os(darwin)
         ghc-options: "-optl-Wl,-lfltkc"
 
-    if (!os(osx) && !os(windows))
+    if (!os(darwin) && !os(windows))
         ghc-options: -pgml g++ "-optl-Wl,--allow-multiple-definition"
                      "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc"
                      "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"
@@ -236,10 +236,10 @@ executable Example4
                      "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc"
                      "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"
 
-    if os(osx)
+    if os(darwin)
         ghc-options: "-optl-Wl,-lfltkc"
 
-    if (!os(osx) && !os(windows))
+    if (!os(darwin) && !os(windows))
         ghc-options: -pgml g++ "-optl-Wl,--allow-multiple-definition"
                      "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc"
                      "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"
@@ -279,10 +279,10 @@ executable Example5
                      "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc"
                      "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"
 
-    if os(osx)
+    if os(darwin)
         ghc-options: "-optl-Wl,-lfltkc"
 
-    if (!os(osx) && !os(windows))
+    if (!os(darwin) && !os(windows))
         ghc-options: -pgml g++ "-optl-Wl,--allow-multiple-definition"
                      "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc"
                      "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"
@@ -320,10 +320,10 @@ executable Example7
                      "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc"
                      "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"
 
-    if os(osx)
+    if os(darwin)
         ghc-options: "-optl-Wl,-lfltkc"
 
-    if (!os(osx) && !os(windows))
+    if (!os(darwin) && !os(windows))
         ghc-options: -pgml g++ "-optl-Wl,--allow-multiple-definition"
                      "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc"
                      "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"
@@ -364,10 +364,10 @@ executable Example8
                      "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc"
                      "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"
 
-    if os(osx)
+    if os(darwin)
         ghc-options: "-optl-Wl,-lfltkc"
 
-    if (!os(osx) && !os(windows))
+    if (!os(darwin) && !os(windows))
         ghc-options: -pgml g++ "-optl-Wl,--allow-multiple-definition"
                      "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc"
                      "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"
@@ -405,10 +405,10 @@ executable Example11
                      "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc"
                      "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"
 
-    if os(osx)
+    if os(darwin)
         ghc-options: "-optl-Wl,-lfltkc"
 
-    if (!os(osx) && !os(windows))
+    if (!os(darwin) && !os(windows))
         ghc-options: -pgml g++ "-optl-Wl,--allow-multiple-definition"
                      "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc"
                      "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"
@@ -446,10 +446,10 @@ executable Example12
                      "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc"
                      "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"
 
-    if os(osx)
+    if os(darwin)
         ghc-options: "-optl-Wl,-lfltkc"
 
-    if (!os(osx) && !os(windows))
+    if (!os(darwin) && !os(windows))
         ghc-options: -pgml g++ "-optl-Wl,--allow-multiple-definition"
                      "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc"
                      "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"
@@ -487,10 +487,10 @@ executable Example13
                      "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc"
                      "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"
 
-    if os(osx)
+    if os(darwin)
         ghc-options: "-optl-Wl,-lfltkc"
 
-    if (!os(osx) && !os(windows))
+    if (!os(darwin) && !os(windows))
         ghc-options: -pgml g++ "-optl-Wl,--allow-multiple-definition"
                      "-optl-Wl,--whole-archive" "-optl-Wl,-Bstatic" "-optl-Wl,-lfltkc"
                      "-optl-Wl,-Bdynamic" "-optl-Wl,--no-whole-archive"


### PR DESCRIPTION
Fixed build on osx/darwin which was caused by an additional space. Plus changing the os check to darwin like it is in fltkhs .
The failure was
```Chart-fltkhs       > Preprocessing library for Chart-fltkhs-0.1.0.6..
Chart-fltkhs       > Building library for Chart-fltkhs-0.1.0.6..
Chart-fltkhs       > target ‘ -optl-Wl,-lfltkc’ is not a module name or a source file
```